### PR TITLE
Remove Key Vault requirement for MongoDB

### DIFF
--- a/.github/workflows/deploy-to-azure.yml
+++ b/.github/workflows/deploy-to-azure.yml
@@ -90,23 +90,6 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
 
-      - name: Get MongoDB Username from Azure Key Vault (for deploy job)
-        id: get-mongo-username-deploy
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "mongo-db-username" --query value -o tsv)
-            echo "secret=$secret_value" >> $GITHUB_OUTPUT
-
-      - name: Get MongoDB Password from Azure Key Vault (for deploy job)
-        id: get-mongo-password-deploy
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "mongo-db-password" --query value -o tsv)
-            echo "secret=$secret_value" >> $GITHUB_OUTPUT
 
       - name: Get Anthropic API Key from Azure Key Vault
         id: get-anthropic-api-key
@@ -162,8 +145,6 @@ jobs:
           az webapp config appsettings set --resource-group ${{ env.RESOURCE_GROUP }} --name ${{ env.AZURE_WEBAPP_NAME }} --settings \
             ACR_LOGIN_SERVER="${{ env.ACR_LOGIN_SERVER }}" \
             IMAGE_TAG="${{ env.IMAGE_TAG }}" \
-            MONGO_USERNAME="${{ steps.get-mongo-username-deploy.outputs.secret }}" \
-            MONGO_PASSWORD="${{ steps.get-mongo-password-deploy.outputs.secret }}" \
             NODE_ENV="production" \
             LOG_LEVEL="info" \
             API_VERSION="v1" \

--- a/README_AZURE.md
+++ b/README_AZURE.md
@@ -65,9 +65,12 @@ The Ethics Dashboard application uses MongoDB to store data including ethical me
    - `STORAGE_ACCOUNT_KEY`
 
 3. **Security Considerations:**
-   - Store these credentials in Azure Key Vault for production deployments
-   - Use Azure Private Endpoints for your storage account in production
-   - Regularly rotate the MongoDB credentials and storage account keys
+   - If you deploy using the provided Docker Compose setup, MongoDB runs inside
+     the container without authentication. The `MONGO_USERNAME` and
+     `MONGO_PASSWORD` variables can be left empty.
+   - Use Azure Private Endpoints for your storage account in production.
+   - Regularly rotate any credentials and storage account keys if you enable
+     authentication.
 
 For more detailed information, see `documents/azure_persistence_setup.md`.
 

--- a/docker-compose.azure.yml
+++ b/docker-compose.azure.yml
@@ -16,11 +16,9 @@ services:
     command:
       - "python3"
       - "/scripts/populate_memes.py"
-    environment:
-      MONGO_USERNAME: ${MONGO_USERNAME}
-      MONGO_PASSWORD: ${MONGO_PASSWORD}
-      MONGO_HOST: ai-mongo
-      MONGO_DB_NAME: ethics_db
+      environment:
+        MONGO_HOST: ai-mongo
+        MONGO_DB_NAME: ethics_db
     restart: on-failure
 
   ai-backend:
@@ -30,11 +28,9 @@ services:
       - db-init
     ports:
       - "5000:5000"
-    environment:
-      MONGO_USERNAME: ${MONGO_USERNAME}
-      MONGO_PASSWORD: ${MONGO_PASSWORD}
-      MONGO_HOST: ai-mongo
-      MONGO_DB_NAME: ethics_db
+      environment:
+        MONGO_HOST: ai-mongo
+        MONGO_DB_NAME: ethics_db
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       GEMINI_API_KEY: ${GEMINI_API_KEY}

--- a/docs/cicd-pipeline-setup.md
+++ b/docs/cicd-pipeline-setup.md
@@ -93,6 +93,7 @@ az keyvault secret set --vault-name "ethics-dash-kv" --name "API-ENDPOINT" --val
 az keyvault secret set --vault-name "ethics-dash-kv" --name "API-VERSION" --value "v2"
 az keyvault secret set --vault-name "ethics-dash-kv" --name "NODE-ENV" --value "production"
 az keyvault secret set --vault-name "ethics-dash-kv" --name "LOG-LEVEL" --value "info"
+
 ```
 
 ### 6. Commit and Push the Workflow File

--- a/documents/azure_persistence_setup.md
+++ b/documents/azure_persistence_setup.md
@@ -69,8 +69,8 @@ The `docker-compose.azure.yml` file has been configured with:
 
 ### 5. Security Considerations
 
-- Use strong, unique passwords for MongoDB authentication
-- Store sensitive credentials in Azure Key Vault and reference them in your deployment
+- Use strong, unique passwords for MongoDB authentication if you choose to enable it.
+- When authentication is enabled, store credentials securely (for example, in Azure Key Vault) and reference them in your deployment.
 - Consider encrypting data at rest by enabling encryption on your storage account
 - Restrict network access to your storage account using firewall rules
 


### PR DESCRIPTION
## Summary
- stop fetching Mongo credentials from Azure Key Vault
- adjust docker-compose and docs to run MongoDB container without authentication
- clarify security notes for optional credential use

## Testing
- `git status --short`