### PR TITLE
Fix Azure Key Vault secret names

### DIFF
--- a/.github/workflows/deploy-to-azure.yml
+++ b/.github/workflows/deploy-to-azure.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "ANTHROPIC_API_KEY" --query value -o tsv)
+            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "anthropic-api-key" --query value -o tsv)
             echo "secret=$secret_value" >> $GITHUB_OUTPUT
 
       - name: Get OpenAI API Key from Azure Key Vault
@@ -106,7 +106,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "OPENAI_API_KEY" --query value -o tsv)
+            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "openai-api-key" --query value -o tsv)
             echo "secret=$secret_value" >> $GITHUB_OUTPUT
 
       - name: Get Gemini API Key from Azure Key Vault
@@ -115,7 +115,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "GEMINI_API_KEY" --query value -o tsv)
+            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "gemini-api-key" --query value -o tsv)
             echo "secret=$secret_value" >> $GITHUB_OUTPUT
 
       - name: Get Google API Key from Azure Key Vault
@@ -124,7 +124,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "GOOGLE_API_KEY" --query value -o tsv)
+            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "google-api-key" --query value -o tsv)
             echo "secret=$secret_value" >> $GITHUB_OUTPUT
 
       - name: Get XAI API Key from Azure Key Vault
@@ -133,7 +133,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "XAI_API_KEY" --query value -o tsv)
+            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "xai-api-key" --query value -o tsv)
             echo "secret=$secret_value" >> $GITHUB_OUTPUT
 
       - name: Enable container logging


### PR DESCRIPTION
## Summary
- use hyphenated secret names when retrieving keys from Azure Key Vault

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest` *(fails: command not found)*