### PR TITLE
Switch secret guidance to GitHub Secrets

### DIFF
--- a/.cursor/rules/ethicsdash.mdc
+++ b/.cursor/rules/ethicsdash.mdc
@@ -15,10 +15,10 @@ As an AI agent assisting with the `Ethics Dashboard` project, follow these guide
 
 4. **Build and Troubleshooting**: Proactively address issues by exploring existing implementation options before suggesting new patterns or technologies. Remove outdated implementations when new ones are adopted, if appropriate. Use mock data only if requested, and avoid stubbing or fake data in production-affecting code unless explicitly directed.
 
-5. **CI/CD Pipeline**: Support the CI/CD architecture with GitHub Actions for automation, Azure Container Registry (ACR) for image storage, and Azure Key Vault for secrets management when relevant. Use OpenID Connect (OIDC) for secure authentication where applicable. Tag container images with 'latest' and commit SHA for traceability if involved in deployment tasks.
+5. **CI/CD Pipeline**: Support the CI/CD architecture with GitHub Actions for automation, Azure Container Registry (ACR) for image storage, and GitHub Secrets for secrets management when relevant. Use OpenID Connect (OIDC) for secure authentication where applicable. Tag container images with 'latest' and commit SHA for traceability if involved in deployment tasks.
 
 6. **Security Practices**: 
-   - Avoid hardcoding secrets in application code. Prefer storing sensitive information (API keys, connection strings, credentials) in Azure Key Vault or secure configurations.
+   - Avoid hardcoding secrets in application code. Prefer storing sensitive information (API keys, connection strings, credentials) in GitHub Secrets or secure configurations.
    - Ensure `.env` files for local development are listed in `.gitignore` and not committed to version control.
    - Suggest secure practices like credential generation, token TTL limits, audit logging, network restrictions, and TLS for sensitive communications when relevant.
    - Document significant security considerations in `Context/prompt.txt` if needed, marking critical decisions with `**`.

--- a/.github/workflows/deploy-to-azure.yml
+++ b/.github/workflows/deploy-to-azure.yml
@@ -91,50 +91,6 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
 
 
-      - name: Get Anthropic API Key from Azure Key Vault
-        id: get-anthropic-api-key
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "anthropic-api-key" --query value -o tsv)
-            echo "secret=$secret_value" >> $GITHUB_OUTPUT
-
-      - name: Get OpenAI API Key from Azure Key Vault
-        id: get-openai-api-key
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "openai-api-key" --query value -o tsv)
-            echo "secret=$secret_value" >> $GITHUB_OUTPUT
-
-      - name: Get Gemini API Key from Azure Key Vault
-        id: get-gemini-api-key
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "gemini-api-key" --query value -o tsv)
-            echo "secret=$secret_value" >> $GITHUB_OUTPUT
-
-      - name: Get Google API Key from Azure Key Vault
-        id: get-google-api-key
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "google-api-key" --query value -o tsv)
-            echo "secret=$secret_value" >> $GITHUB_OUTPUT
-
-      - name: Get XAI API Key from Azure Key Vault
-        id: get-xai-api-key
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            secret_value=$(az keyvault secret show --vault-name "ethicsdash-kv-jc-01" --name "xai-api-key" --query value -o tsv)
-            echo "secret=$secret_value" >> $GITHUB_OUTPUT
 
       - name: Enable container logging
         run: |
@@ -151,11 +107,11 @@ jobs:
             WEBSITES_ENABLE_APP_SERVICE_STORAGE=false \
             BACKEND_HOST="ai-backend" \
             BACKEND_PORT="5000" \
-            ANTHROPIC_API_KEY="${{ steps.get-anthropic-api-key.outputs.secret }}" \
-            OPENAI_API_KEY="${{ steps.get-openai-api-key.outputs.secret }}" \
-            GEMINI_API_KEY="${{ steps.get-gemini-api-key.outputs.secret }}" \
-            GOOGLE_API_KEY="${{ steps.get-google-api-key.outputs.secret }}" \
-            XAI_API_KEY="${{ steps.get-xai-api-key.outputs.secret }}" \
+            ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}" \
+            OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}" \
+            GEMINI_API_KEY="${{ secrets.GEMINI_API_KEY }}" \
+            GOOGLE_API_KEY="${{ secrets.GOOGLE_API_KEY }}" \
+            XAI_API_KEY="${{ secrets.XAI_API_KEY }}" \
             DEFAULT_LLM_MODEL="gpt-4" \
             ANALYSIS_LLM_MODEL="claude-3-opus-20240229" \
             OPENAI_API_ENDPOINT="https://api.openai.com/v1" \

--- a/README_AZURE.md
+++ b/README_AZURE.md
@@ -93,4 +93,4 @@ This workflow only pushes images to ACR. To deploy the application, you need to:
 
 2.  **Configure Deployment:** Update your chosen service to use the images tagged with the latest Git SHA from your ACR. This often involves updating service definitions, ARM templates, Bicep files, or Terraform configurations. You might extend the GitHub Actions workflow to include deployment steps using Azure CLI commands (`az webapp config container set`, `az container create`, `kubectl apply`, etc.).
 
-3.  **Manage Secrets:** Ensure your deployed application has secure access to necessary secrets (API keys, Database URI) using Azure Key Vault or App Service configuration. 
+3.  **Manage Secrets:** Ensure your deployed application has secure access to necessary secrets (API keys, Database URI). Store them as GitHub repository secrets and reference them in your workflow or App Service configuration.

--- a/README_GCP.md
+++ b/README_GCP.md
@@ -48,7 +48,7 @@ This guide explains how to set up and use the GitHub Actions workflow (`.github/
     * `GCP_ARTIFACT_REGISTRY_REPO`: The name of your Artifact Registry repository (e.g., `ethics-dash-repo`).
     * `GCP_CLOUD_RUN_REGION`: The region where you want to deploy Cloud Run services (e.g., `us-central1`).
     * `GCP_MONGO_URI`: The **connection string** for your cloud MongoDB instance (e.g., MongoDB Atlas connection string). **Store this securely!**
-    * **(Optional but Recommended)** Store LLM API keys in GCP Secret Manager and grant the Service Account access, then reference them in Cloud Run environment variables. Alternatively, store them as GitHub secrets and pass them during deployment (less secure).
+    * Store LLM API keys as GitHub repository secrets and reference them in the workflow. You may also use GCP Secret Manager if preferred.
 
 5.  **Understand the Workflow:**
     * The `.github/workflows/gcp_deploy.yml` workflow triggers on pushes to the `main` branch or manually.
@@ -76,6 +76,6 @@ Once the workflow completes successfully, the frontend application will be avail
 ## Important Notes
 
 -   **DB Initialization:** This workflow does *not* automatically run the `db-init` container. You will need to run the database population script (`scripts/populate_memes.py`) manually against your cloud MongoDB instance the first time, or create a GCP Cloud Build job or a GKE Job to handle this initialization step using the `db-init` image (which you'd need to add build/push steps for in the workflow).
--   **Secret Management:** Passing secrets like `GCP_MONGO_URI` directly as GitHub secrets is less secure than using GCP Secret Manager and granting the Cloud Run service account access. Adapt the workflow accordingly for better security.
+-   **Secret Management:** Store secrets like `GCP_MONGO_URI` as GitHub repository secrets for convenience. You can also use GCP Secret Manager and grant the Cloud Run service account access if desired.
 -   **Nginx Configuration:** The `ai-frontend` (Nginx) container needs to be correctly configured (in its `nginx.conf` or similar) to proxy API calls (`/api/*`) to the backend Cloud Run service URL. The workflow attempts to pass this dynamically, but verify the Nginx configuration handles it.
 -   **Cloud Run Settings:** Adjust Cloud Run flags (`--min-instances`, `--max-instances`) 

--- a/docs/cicd-pipeline-setup.md
+++ b/docs/cicd-pipeline-setup.md
@@ -9,7 +9,7 @@ The CI/CD pipeline follows this flow:
 2. GitHub commit
 3. GitHub Actions workflow
 4. Azure Container Registry (ACR)
-5. Application build with secrets from Azure Key Vault
+5. Application build with secrets from GitHub Secrets
 
 ## Prerequisites
 
@@ -57,7 +57,6 @@ mkdir -p scripts
   -ResourceGroupName "ethics-dash-rg" `
   -Location "eastus" `
   -AcrName "ethicsdashacr" `
-  -KeyVaultName "ethics-dash-kv" `
   -GitHubRepoName "Ethics_Dash" `
   -GitHubOrgName "YourGitHubOrg"
 ```
@@ -75,26 +74,22 @@ The following secrets should be set:
 - AZURE_TENANT_ID
 - AZURE_SUBSCRIPTION_ID
 - ACR_REGISTRY_NAME
-- KEY_VAULT_NAME
+- ANTHROPIC_API_KEY
+- OPENAI_API_KEY
+- GEMINI_API_KEY
+- GOOGLE_API_KEY
+- XAI_API_KEY
 
-### 5. Update Key Vault Secrets
+### 5. Update GitHub Secrets
 
-Replace the placeholder secrets in Key Vault with your actual values:
+Replace the placeholder secrets in your repository with actual values:
 
-```powershell
-# Example: Update API key
-az keyvault secret set --vault-name "ethics-dash-kv" --name "API-KEY" --value "your-actual-api-key"
-
-# Example: Update API secret
-az keyvault secret set --vault-name "ethics-dash-kv" --name "API-SECRET" --value "your-actual-api-secret"
-
-# Update other secrets as needed
-az keyvault secret set --vault-name "ethics-dash-kv" --name "API-ENDPOINT" --value "https://your-actual-api-endpoint.com"
-az keyvault secret set --vault-name "ethics-dash-kv" --name "API-VERSION" --value "v2"
-az keyvault secret set --vault-name "ethics-dash-kv" --name "NODE-ENV" --value "production"
-az keyvault secret set --vault-name "ethics-dash-kv" --name "LOG-LEVEL" --value "info"
-
-```
+```bash
+gh secret set ANTHROPIC_API_KEY -b "your-actual-api-key"
+gh secret set OPENAI_API_KEY -b "your-actual-openai-api-key"
+gh secret set GEMINI_API_KEY -b "your-actual-gemini-api-key"
+gh secret set GOOGLE_API_KEY -b "your-actual-google-api-key"
+gh secret set XAI_API_KEY -b "your-actual-xai-api-key"
 
 ### 6. Commit and Push the Workflow File
 
@@ -138,13 +133,8 @@ You can trigger the workflow manually from the GitHub Actions tab in your reposi
    az role assignment create --assignee $AZURE_CLIENT_ID --scope "/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/ethics-dash-rg/providers/Microsoft.ContainerRegistry/registries/ethicsdashacr" --role "AcrPush"
    ```
 
-3. **Key Vault access issues:**
-   - Check Key Vault access policies or RBAC permissions
-
-   ```powershell
-   # Reassign Key Vault Secrets User role if needed
-   az role assignment create --assignee $AZURE_CLIENT_ID --scope "/subscriptions/$AZURE_SUBSCRIPTION_ID/resourceGroups/ethics-dash-rg/providers/Microsoft.KeyVault/vaults/ethics-dash-kv" --role "Key Vault Secrets User"
-   ```
+3. **GitHub secret access issues:**
+   - Ensure your GitHub token has permission to read repository secrets.
 
 ## Testing the Pipeline
 
@@ -178,5 +168,5 @@ Test your changes locally before pushing to GitHub to trigger the CI/CD pipeline
 
 - [GitHub Actions Documentation](https://docs.github.com/en/actions)
 - [Azure Container Registry Documentation](https://docs.microsoft.com/en-us/azure/container-registry/)
-- [Azure Key Vault Documentation](https://docs.microsoft.com/en-us/azure/key-vault/)
+- [GitHub Secrets Documentation](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
 - [GitHub OIDC with Azure](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure) 

--- a/documents/azure_persistence_setup.md
+++ b/documents/azure_persistence_setup.md
@@ -70,7 +70,7 @@ The `docker-compose.azure.yml` file has been configured with:
 ### 5. Security Considerations
 
 - Use strong, unique passwords for MongoDB authentication if you choose to enable it.
-- When authentication is enabled, store credentials securely (for example, in Azure Key Vault) and reference them in your deployment.
+- When authentication is enabled, store credentials securely (for example, in GitHub Secrets) and reference them in your deployment.
 - Consider encrypting data at rest by enabling encryption on your storage account
 - Restrict network access to your storage account using firewall rules
 

--- a/root_env_example
+++ b/root_env_example
@@ -60,5 +60,5 @@ API_VERSION=v1
 API_KEY=replace_with_strong_api_key
 API_SECRET=replace_with_strong_api_secret
 
-# NOTE: For production, store secrets in Azure Key Vault or a secure secret manager.
+# NOTE: For production, store secrets as GitHub repository secrets or another secure secret manager.
 # This file is a template. Do not commit real secrets to version control. 

--- a/scripts/setup_azure_mongodb_persistence.ps1
+++ b/scripts/setup_azure_mongodb_persistence.ps1
@@ -84,4 +84,4 @@ $envContent | Out-File -FilePath $OutputEnvFile -Encoding utf8
 Write-Host "Setup completed successfully!" -ForegroundColor Green
 Write-Host "MongoDB persistence settings have been saved to $OutputEnvFile" -ForegroundColor Green
 Write-Host "Important: Store these credentials securely and add them to your Azure deployment environment variables." -ForegroundColor Yellow
-Write-Host "For production use, consider using Azure Key Vault for secure credential storage." -ForegroundColor Yellow 
+Write-Host "For production use, consider storing secrets as GitHub repository secrets." -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- update docs to recommend GitHub Secrets
- remove Azure Key Vault usage from CI/CD workflow
- tweak persistence setup guidance
- adjust scripts and docs accordingly

## Testing
- `npm test` *(fails: react-scripts not found)*